### PR TITLE
Fix infinite loop in iOS 14 when embedding NetworkImage inside HStack

### DIFF
--- a/Sources/NetworkImage/SwiftUI/NetworkImageViewModel.swift
+++ b/Sources/NetworkImage/SwiftUI/NetworkImageViewModel.swift
@@ -2,56 +2,43 @@ import Combine
 import CombineSchedulers
 import SwiftUI
 
-final class NetworkImageViewModel {
+final class NetworkImageViewModel: ObservableObject {
   struct Context {
     var transaction: Transaction
     var imageLoader: NetworkImageLoader
   }
 
   enum State: Equatable {
-    case empty
-    case success(URL, CGFloat, Image)
+    case empty(url: URL, scale: CGFloat)
+    case success(Image)
     case failure
 
-    var url: URL? {
-      guard case .success(let url, _, _) = self else {
-        return nil
-      }
-      return url
-    }
-
-    var scale: CGFloat? {
-      guard case .success(_, let scale, _) = self else {
-        return nil
-      }
-      return scale
-    }
-
     var image: Image? {
-      guard case .success(_, _, let image) = self else {
+      guard case .success(let image) = self else {
         return nil
       }
       return image
     }
   }
 
-  @Published private(set) var state: State = .empty
+  @Published private(set) var state: State
   private var cancellable: AnyCancellable?
 
-  func update(url: URL?, scale: CGFloat, context: Context) {
-    guard let url = url else {
-      withTransaction(context.transaction) {
-        self.state = .failure
-      }
-      return
+  init(url: URL?, scale: CGFloat) {
+    if let url = url {
+      self.state = .empty(url: url, scale: scale)
+    } else {
+      self.state = .failure
     }
+  }
 
-    guard url != self.state.url || scale != self.state.scale else {
+  func onAppear(context: Context) {
+    guard case .empty(let url, let scale) = self.state else {
       return
     }
 
     self.cancellable = context.imageLoader.image(for: url, scale: scale)
-      .map { .success(url, scale, .init(platformImage: $0)) }
+      .map { .success(.init(platformImage: $0)) }
       .replaceError(with: .failure)
       .receive(on: UIScheduler.shared)
       .sink { [weak self] state in

--- a/Sources/NetworkImage/SwiftUI/NetworkImageViewModel.swift
+++ b/Sources/NetworkImage/SwiftUI/NetworkImageViewModel.swift
@@ -1,0 +1,63 @@
+import Combine
+import CombineSchedulers
+import SwiftUI
+
+final class NetworkImageViewModel {
+  struct Context {
+    var transaction: Transaction
+    var imageLoader: NetworkImageLoader
+  }
+
+  enum State: Equatable {
+    case empty
+    case success(URL, CGFloat, Image)
+    case failure
+
+    var url: URL? {
+      guard case .success(let url, _, _) = self else {
+        return nil
+      }
+      return url
+    }
+
+    var scale: CGFloat? {
+      guard case .success(_, let scale, _) = self else {
+        return nil
+      }
+      return scale
+    }
+
+    var image: Image? {
+      guard case .success(_, _, let image) = self else {
+        return nil
+      }
+      return image
+    }
+  }
+
+  @Published private(set) var state: State = .empty
+  private var cancellable: AnyCancellable?
+
+  func update(url: URL?, scale: CGFloat, context: Context) {
+    guard let url = url else {
+      withTransaction(context.transaction) {
+        self.state = .failure
+      }
+      return
+    }
+
+    guard url != self.state.url || scale != self.state.scale else {
+      return
+    }
+
+    self.cancellable = context.imageLoader.image(for: url, scale: scale)
+      .map { .success(url, scale, .init(platformImage: $0)) }
+      .replaceError(with: .failure)
+      .receive(on: UIScheduler.shared)
+      .sink { [weak self] state in
+        withTransaction(context.transaction) {
+          self?.state = state
+        }
+      }
+  }
+}


### PR DESCRIPTION
Replacing `@State` and `.onReceive` with an `@ObservableObject` fixes the issue.