### PR TITLE
Add an initializer that provides the original image size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,14 +37,14 @@ playground.xcworkspace
 # Swift Package Manager
 #
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-# Packages/
-# Package.pins
-# Package.resolved
+Packages/
+Package.pins
+Package.resolved
 # *.xcodeproj
 #
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
-# .swiftpm
+.swiftpm
 
 .build/
 
@@ -88,3 +88,5 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+.DS_Store

--- a/Sources/NetworkImage/SwiftUI/NetworkImage.swift
+++ b/Sources/NetworkImage/SwiftUI/NetworkImage.swift
@@ -120,7 +120,7 @@ public struct NetworkImage<Content>: View where Content: View {
         switch state {
         case .notRequested, .loading, .failure:
           placeholder()
-        case .success(let image):
+        case .success(let image, _):
           content(image)
         }
       }
@@ -155,8 +155,45 @@ public struct NetworkImage<Content>: View where Content: View {
         switch state {
         case .notRequested, .loading:
           placeholder()
-        case .success(let image):
+        case .success(let image, _):
           content(image)
+        case .failure:
+          fallback()
+        }
+      }
+    )
+  }
+
+  /// Loads and displays a modifiable image from the specified URL using a custom placeholder
+  /// until the image loads and a custom fallback if the image fails to load or the URL is `nil`.
+  ///
+  /// - Parameters:
+  ///   - url: The URL where the image is located.
+  ///   - scale: The scale to use for the image. The default is `1`.
+  ///   - transaction: The transaction to use when the state changes.
+  ///   - content: A closure that takes the loaded image and its size as an input, and
+  ///     returns the view to show. You can return the image directly, or
+  ///     modify it as needed before returning it.
+  ///   - placeholder: A closure that returns the view to display while the image is loading.
+  ///   - fallback: A closure that returns the view to display when the URL is `nil` or an error has occurred.
+  public init<P, I, F>(
+    url: URL?,
+    scale: CGFloat = 1,
+    transaction: Transaction = .init(),
+    @ViewBuilder content: @escaping (Image, CGSize) -> I,
+    @ViewBuilder placeholder: @escaping () -> P,
+    @ViewBuilder fallback: @escaping () -> F
+  ) where Content == _ConditionalContent<_ConditionalContent<P, I>, F>, P: View, I: View, F: View {
+    self.init(
+      url: url,
+      scale: scale,
+      transaction: transaction,
+      content: { state in
+        switch state {
+        case .notRequested, .loading:
+          placeholder()
+        case let .success(image, size):
+          content(image, size)
         case .failure:
           fallback()
         }

--- a/Sources/NetworkImage/SwiftUI/NetworkImageViewModel.swift
+++ b/Sources/NetworkImage/SwiftUI/NetworkImageViewModel.swift
@@ -11,11 +11,11 @@ final class NetworkImageViewModel: ObservableObject {
   enum State: Equatable {
     case notRequested
     case loading
-    case success(Image)
+    case success(Image, CGSize)
     case failure
 
     var image: Image? {
-      guard case .success(let image) = self else {
+      guard case .success(let image, _) = self else {
         return nil
       }
       return image
@@ -37,7 +37,7 @@ final class NetworkImageViewModel: ObservableObject {
     if let url = url {
       state = .loading
       cancellable = environment.imageLoader.image(for: url, scale: scale)
-        .map { .success(.init(platformImage: $0)) }
+        .map { .success(.init(platformImage: $0), $0.size) }
         .replaceError(with: .failure)
         .receive(on: UIScheduler.shared)
         .sink { [weak self] state in


### PR DESCRIPTION
Add an initializer to `NetworkImage` that provides the original image size in the `content` block.